### PR TITLE
Reemplazo de log4j por log4j2 en reportes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,21 +195,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-core</artifactId>
-			<version>1.19</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-json</artifactId>
-			<version>1.19</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-servlet</artifactId>
-			<version>1.19</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.11</version>

--- a/src/main/java/mx/com/ferbo/controller/ReporteEstadoResultadosBean.java
+++ b/src/main/java/mx/com/ferbo/controller/ReporteEstadoResultadosBean.java
@@ -9,7 +9,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
@@ -18,14 +17,12 @@ import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.primefaces.PrimeFaces;
 
-import mx.com.ferbo.dao.BancoDAO;
 import mx.com.ferbo.dao.ClienteDAO;
 import mx.com.ferbo.dao.EmisoresCFDISDAO;
-import mx.com.ferbo.model.Bancos;
-import mx.com.ferbo.model.Cliente;
 import mx.com.ferbo.model.EmisoresCFDIS;
 import mx.com.ferbo.util.EntityManagerUtil;
 import mx.com.ferbo.util.JasperReportUtil;
@@ -36,7 +33,7 @@ import mx.com.ferbo.util.conexion;
 public class ReporteEstadoResultadosBean implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
-	private static Logger log = Logger.getLogger(ReporteAlmacenFechaBean.class);
+	private static Logger log = LogManager.getLogger(ReporteAlmacenFechaBean.class);
 	
 	private List<EmisoresCFDIS> listaEmisores;
 	

--- a/src/main/java/mx/com/ferbo/controller/ReporteInventarioOcupacionCamaraBean.java
+++ b/src/main/java/mx/com/ferbo/controller/ReporteInventarioOcupacionCamaraBean.java
@@ -22,7 +22,8 @@ import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.primefaces.PrimeFaces;
 import org.primefaces.model.charts.ChartData;
 import org.primefaces.model.charts.pie.PieChartDataSet;
@@ -47,7 +48,7 @@ import net.sf.jasperreports.engine.JRException;
 public class ReporteInventarioOcupacionCamaraBean implements Serializable{
 	
 	private static final long serialVersionUID = 1L;
-	private static Logger log = Logger.getLogger(ReporteInventarioOcupacionCamaraBean.class);
+	private static Logger log = LogManager.getLogger(ReporteInventarioOcupacionCamaraBean.class);
 
 	Integer idCliente = null;
 	Integer idPlanta = null;

--- a/src/main/java/mx/com/ferbo/dao/RepEstadoCuentaDAO.java
+++ b/src/main/java/mx/com/ferbo/dao/RepEstadoCuentaDAO.java
@@ -7,14 +7,15 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import mx.com.ferbo.commons.dao.IBaseDAO;
 import mx.com.ferbo.ui.RepEstadoCuenta;
 import mx.com.ferbo.util.EntityManagerUtil;
 
 public class RepEstadoCuentaDAO extends IBaseDAO<RepEstadoCuenta, Integer> {
-private static Logger log = Logger.getLogger(RepEstadoCuentaDAO.class);
+private static Logger log = LogManager.getLogger(RepEstadoCuentaDAO.class);
 
 	@Override
 	public RepEstadoCuenta buscarPorId(Integer id) {

--- a/src/main/java/mx/com/ferbo/dao/RepOcupacionCamaraDAO.java
+++ b/src/main/java/mx/com/ferbo/dao/RepOcupacionCamaraDAO.java
@@ -7,14 +7,15 @@ import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import mx.com.ferbo.ui.OcupacionCamara;
 import mx.com.ferbo.util.EntityManagerUtil;
 
 public class RepOcupacionCamaraDAO {
 	
-	private static Logger log = Logger.getLogger(RepOcupacionCamaraDAO.class);
+	private static Logger log = LogManager.getLogger(RepOcupacionCamaraDAO.class);
 	
 	@SuppressWarnings("unchecked")
 	public List<OcupacionCamara> ocupacionCamara(Date fecha, Integer idCliente, Integer idPlanta, Integer idCamara){

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -122,23 +122,4 @@
 		<res-type>javax.mail.Session</res-type>
 		<res-auth>Container</res-auth>
 	</resource-ref>
-	<display-name>Archetype Created Web Application</display-name>
-	<servlet>
-	<servlet-name>Jersey Web Application</servlet-name>
-	<servlet-class>com.sun.jesery.spi.container.servlet.ServletContainer</servlet-class>
-	<init-param>
-		<param-name>com.sun.jersey.config.property.packages</param-name>
-		<param-value>com.javarevolutions.ws.rest</param-value>
-	</init-param>
-	<init-param>
-			<param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
-		<param-value>true</param-value>
-	</init-param>
-	<load-on-startup>1</load-on-startup>
-	</servlet>
-	<servlet-mapping>
-			<servlet-name>Jersey Web Application</servlet-name>
-			<url-pattern>/rest/*</url-pattern>
-	</servlet-mapping>
-	
 </web-app>


### PR DESCRIPTION
Reemplazo de biblioteca log4j por log4j2 en Reportes de ocupación de cámaras y Estado de cuenta.