### PR TITLE
Agregar la propiedad excedente a la lógica de tarima

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/ConstanciaDeDepositoBean.java
+++ b/src/main/java/mx/com/ferbo/controller/ConstanciaDeDepositoBean.java
@@ -185,11 +185,14 @@ public class ConstanciaDeDepositoBean implements Serializable {
 	private Date maxDate;
 	private SerieConstancia serie;
 	private Usuario usuario;
-	
+        
 	private StreamedContent file;
 	
 	private FacesContext context;
     private HttpServletRequest request;
+    
+        private Integer tarimasPermitidas;
+        private Integer tarimasInventario;
     
 	public ConstanciaDeDepositoBean() {
 		clienteDAO = new ClienteDAO();
@@ -282,7 +285,7 @@ public class ConstanciaDeDepositoBean implements Serializable {
 
 			maxDate = new Date(today.getTime() );
 			this.file = DefaultStreamedContent.builder().contentType("application/pdf").contentLength(bytes.length)
-					.name("ticket.pdf").stream(() -> new ByteArrayInputStream(bytes)).build();
+					.name("ticket.pdf").stream(() -> new ByteArrayInputStream(bytes)).build();                        
 		} catch(Exception ex) {
 			
 		} finally {
@@ -570,6 +573,14 @@ public class ConstanciaDeDepositoBean implements Serializable {
 		PrimeFaces.current().ajax().update(":form:txtPedimento", ":form:txtSAP", ":form:txtLote",
 				":form:fechaCaducidad", ":form:txtOtro", ":form:precioServicio", "form:congelacion",
 				":form:conservacion", ":form:refrigeracion", ":form:maniobras","form:txtCodigo");
+                
+                
+                    /*Si el aviso contine contienen como propiedad un maximo de tarimas:
+                        this.tarimasPermitidas = el dato extraido de la base de datos
+                        this.tarimasInventario = el dato calculado desde un dao
+                      Si no, simplemente no hacer nada
+                    */
+                
 	}
 	
 	public void addTarima() {
@@ -601,6 +612,9 @@ public class ConstanciaDeDepositoBean implements Serializable {
 				tarima.setId(idTarima++);
 				tarima.setNombre(String.format("%s-%s", this.constanciaDeDeposito.getFolioCliente(), idTarima));
 				tarima.setPartidas(new ArrayList<Partida>());
+                                /*if(i > (this.tarimasPermitidas - this.tarimasInventario)){
+                                    tarima.setExcedente(Boolean.TRUE);
+                                }*/
 				this.tarimas.add(tarima);	
 			}
 			
@@ -1915,5 +1929,5 @@ public class ConstanciaDeDepositoBean implements Serializable {
 
 	public void setTarima(Tarima tarima) {
 		this.tarima = tarima;
-	}
+	}        
 }

--- a/src/main/java/mx/com/ferbo/controller/ConstanciaDeDepositoBean.java
+++ b/src/main/java/mx/com/ferbo/controller/ConstanciaDeDepositoBean.java
@@ -191,9 +191,6 @@ public class ConstanciaDeDepositoBean implements Serializable {
 	private FacesContext context;
     private HttpServletRequest request;
     
-        private Integer tarimasPermitidas;
-        private Integer tarimasInventario;
-    
 	public ConstanciaDeDepositoBean() {
 		clienteDAO = new ClienteDAO();
 		plantaDAO = new PlantaDAO();
@@ -575,11 +572,6 @@ public class ConstanciaDeDepositoBean implements Serializable {
 				":form:conservacion", ":form:refrigeracion", ":form:maniobras","form:txtCodigo");
                 
                 
-                    /*Si el aviso contine contienen como propiedad un maximo de tarimas:
-                        this.tarimasPermitidas = el dato extraido de la base de datos
-                        this.tarimasInventario = el dato calculado desde un dao
-                      Si no, simplemente no hacer nada
-                    */
                 
 	}
 	
@@ -612,9 +604,6 @@ public class ConstanciaDeDepositoBean implements Serializable {
 				tarima.setId(idTarima++);
 				tarima.setNombre(String.format("%s-%s", this.constanciaDeDeposito.getFolioCliente(), idTarima));
 				tarima.setPartidas(new ArrayList<Partida>());
-                                /*if(i > (this.tarimasPermitidas - this.tarimasInventario)){
-                                    tarima.setExcedente(Boolean.TRUE);
-                                }*/
 				this.tarimas.add(tarima);	
 			}
 			

--- a/src/main/java/mx/com/ferbo/model/Tarima.java
+++ b/src/main/java/mx/com/ferbo/model/Tarima.java
@@ -14,6 +14,7 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
  
@@ -40,6 +41,9 @@ public class Tarima implements Serializable {
 	@Basic(optional = false)
 	@Size(max = 50)
 	private String nombre;
+        
+        @Column(name = "st_excedente")
+        private Boolean excedente = Boolean.FALSE;
 
 	@OneToMany(mappedBy = "tarima")
 	private List<Partida> partidas;
@@ -95,6 +99,14 @@ public class Tarima implements Serializable {
 	public void setNombre(String nombre) {
 		this.nombre = nombre;
 	}
+
+        public Boolean getExcedente() {
+            return excedente;
+        }
+
+        public void setExcedente(Boolean excedente) {
+            this.excedente = excedente;
+        }
 	
 	public List<Partida> getPartidas() {
 		return partidas;

--- a/src/main/webapp/inventarios/constanciaDeposito.xhtml
+++ b/src/main/webapp/inventarios/constanciaDeposito.xhtml
@@ -161,6 +161,11 @@
 									<span style="padding-left: 1rem; padding-right: 1rem;">
 										<p:outputLabel value="TARIMA #{tarima.nombre}"></p:outputLabel>
 									</span>	
+                                                                        <span>
+                                                                            <p:selectBooleanCheckbox id="excedente" itemLabel="Excedente" value="#{tarima.excedente}">
+                                                                                        <p:ajax process="@this"></p:ajax>
+                                                                                </p:selectBooleanCheckbox>
+                                                                        </span>
 									<span style="padding-left: 1rem; padding-right: 1rem;">
 										<p:commandButton icon="pi pi-trash" value="Eliminar tarima" styleClass="ui-button-danger" action="#{constanciaDeDepositoBean.deleteTarima(tarima)}">
 											<p:confirm header="Eliminar tarima" message="¿Está seguro que quiere eliminar la tarima?" icon="pi pi-exclamation-triangle" />

--- a/src/main/webapp/inventarios/consultarConstanciaDeDeposito.xhtml
+++ b/src/main/webapp/inventarios/consultarConstanciaDeDeposito.xhtml
@@ -200,9 +200,14 @@
 				    <p:tab id="tabTarimas" title="Tarimas">
 				    	<div class="col-12 md:col-6 lg:col-4 xl:col-3">
 				    		<p:dataTable value="#{consultarConstanciaDeDepositoBean.tarimas}" var="tarima" rows="5" paginator="true" paginatorPosition="bottom" emptyMessage="No hay tarimas registradas">
-				    			<p:column>
+                                                        <p:column>
 					    			<p:outputLabel value="#{tarima.nombre}"></p:outputLabel>
 					    		</p:column>
+                                                        <p:column>
+                                                            <p:selectBooleanCheckbox id="excedente" itemLabel="Excedente" value="#{tarima.excedente}">
+                                                                                        <p:ajax process="@this"></p:ajax>
+                                                            </p:selectBooleanCheckbox>
+                                                        </p:column>
 					    		<p:column>
 					    			<p:outputLabel value="#{tarima.partidas.size()} producto(s)"></p:outputLabel>
 					    		</p:column>


### PR DESCRIPTION
- Primero: en la pantalla "Alta constancia de depósito", una vez que se agregan tarimas a la constancia de depósito, se muestra el nombre de la tarima, en esta sección, se ha agregado un botón de chequeo, para definir si la tarima es excedente o no.

- Segundo:  en la pantalla "Consulta constancia de depósito" al momento de editar la información de alguna constancia, en la sección de tarima, para cada tarima, se agrega un botón de chequeo para editar esta información en cualquier momento.