### PR TITLE
Corregir búsqueda de entradas no facturadas

### DIFF
--- a/src/main/java/mx/com/ferbo/dao/FacturacionDepositosDAO.java
+++ b/src/main/java/mx/com/ferbo/dao/FacturacionDepositosDAO.java
@@ -72,7 +72,7 @@ public class FacturacionDepositosDAO extends IBaseDAO<ConstanciaDeDeposito, Inte
 					+ "	SELECT cf.* FROM constancia_factura cf "
 					+ "	INNER JOIN factura f ON cf.factura = f.id "
 					+ "	WHERE f.status NOT IN (0,2) "
-					+ ") tCF ON cdd.FOLIO = tCF.folio "
+					+ ") tCF ON cdd.FOLIO = tCF.folio AND cdd.FECHA_INGRESO = tCF.vigencia_inicio "
 					+ "INNER JOIN ( "
 					+ "	select DISTINCT p.FOLIO, plt.PLANTA_CVE, plt.PLANTA_DS from partida p "
 					+ "	INNER JOIN camara cam ON p.CAMARA_CVE = cam.CAMARA_CVE  "


### PR DESCRIPTION
En la facturación por constancias (entradas) se corrige la búsqueda de folios que no han sido facturados. Se realiza el cruce entre constancia_factura y constancia_de_deposito, verificando que la fecha de inicio de la primera vigencia facturada corresponda con la fecha de ingreso de la entrada.

En caso de no existir esta coincidencia, se entrega la constancia de depósito a la vista.